### PR TITLE
SPIFFS (test)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,6 +14,6 @@
 	"mounts": [
 		"type=bind,source=${localWorkspaceFolder},target=/workspace"
 	],
-	"image": "esp8266-rtos-sdk",
+	"image": "esp8266-rtos-sdk:v1.0.0",
 	"remoteUser": "root"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 .devcontainer/docker
 build/
 sdkconfig
+sdkconfig.old
 README.md*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,20 @@ include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
 # Ustawienie zmiennej środowiskowej z ścieżką do SDK i własnych komponentów (wewnątrz kontenera)
 set(EXTRA_COMPONENT_DIRS /opt/esp/ESP8266_RTOS_SDK/components
-    "${PROJECT_DIR}/../components")
+    "${PROJECT_DIR}/components")
 
 # Nazwa projektu
 project(nESP_WiFi_Tutorials)
+
+# Wczytaj zawartość pliku tekst.txt do zmiennej
+file(READ "${CMAKE_SOURCE_DIR}/data/tekst.txt" TEKST_TRESC)
+
+# Zamień nowe linie i inne specjalne znaki na odpowiednie formaty w C
+string(REPLACE "\n" "\\n\"\n\"" TEKST_TRESC "${TEKST_TRESC}")
+string(REPLACE "\"" "\\\"" TEKST_TRESC "${TEKST_TRESC}")
+
+# Wygeneruj tekst.h na podstawie szablonu tekst.h.in
+configure_file("${CMAKE_SOURCE_DIR}/data/tekst.h.in" "${CMAKE_BINARY_DIR}/tekst.h")
+
+# Dodaj katalog binarny do include directories
+include_directories("${CMAKE_BINARY_DIR}")

--- a/components/init_fun/init_fun.c
+++ b/components/init_fun/init_fun.c
@@ -36,6 +36,8 @@ static void wifi_event_handler(void *arg, esp_event_base_t event_base,
  *******************************************************************************/
 void gpio_init(void)
 {
+    ESP_LOGI(TAG, "Initializing GPIO\r\n");
+
     gpio_config_t io_conf;
     io_conf.pin_bit_mask = ((1 << 2));
     io_conf.mode = GPIO_MODE_OUTPUT;
@@ -43,7 +45,66 @@ void gpio_init(void)
     io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
     io_conf.intr_type = GPIO_INTR_DISABLE;
 
-    gpio_config(&io_conf);
+    esp_err_t ERR = gpio_config(&io_conf);
+    if (ERR != ESP_OK)
+    {
+        ESP_LOGI(TAG, "Failed to initialize GPIO\r\n");
+    }
+    else
+    {
+        ESP_LOGI(TAG, "Successfully initialized GPIO\r\n");
+    }
+}
+
+/******************************************************************************
+ * FunctionName : spiffs_init
+ * Description  : initializes SPIFFS.
+ * Parameters   : none
+ * Returns      : none
+ *******************************************************************************/
+void spiffs_init(void)
+{
+    ESP_LOGI(TAG, "Initializing SPIFFS\r\n");
+
+    esp_vfs_spiffs_conf_t spiffs_conf;         // Konfiguracja SPIFFS
+    spiffs_conf.base_path = "/spiffs";         // Ścieżka bazowa dla SPIFFS
+    spiffs_conf.partition_label = NULL;        // Domyślna partycja SPIFFS
+    spiffs_conf.max_files = 5;                 // Maksymalna liczba otwartych plików
+    spiffs_conf.format_if_mount_failed = true; // Formatowanie, jeśli montowanie się nie powiodło
+
+    esp_err_t ERR = esp_vfs_spiffs_register(&spiffs_conf); // Zainicjuj i zamontuj system plików SPIFFS na podstawie powyższej konfiguracji
+    if (ERR != ESP_OK)
+    {
+        if (ERR == ESP_FAIL)
+        {
+            ESP_LOGE(TAG, "Failed to mount or format filesystem\r\n"); // Błąd montowania lub formatowania systemu
+        }
+        else if (ERR == ESP_ERR_NOT_FOUND)
+        {
+            ESP_LOGE(TAG, "Failed to find SPIFFS partition\r\n"); // Nie znaleziono partycji SPIFFS
+        }
+        else
+        {
+            ESP_LOGE(TAG, "Failed to initialize SPIFFS (%s)\r\n", esp_err_to_name(ERR)); // Inny błąd inicjalizacji SPIFFS
+        }
+        return;
+    }
+    else
+    {
+        ESP_LOGI(TAG, "Successfully initialized SPIFFS\r\n");
+    }
+}
+
+/******************************************************************************
+ * FunctionName : spiffs_deinit
+ * Description  : shut down and deinitializes SPIFFS.
+ * Parameters   : none
+ * Returns      : none
+ *******************************************************************************/
+void spiffs_deinit(void)
+{
+    esp_vfs_spiffs_unregister(NULL); // Odmontowanie partycji SPIFFS i wyłączenie systemu SPIFFS
+    ESP_LOGI(TAG, "SPIFFS unmounted\r\n");
 }
 
 /******************************************************************************

--- a/components/init_fun/init_fun.h
+++ b/components/init_fun/init_fun.h
@@ -11,6 +11,8 @@
 #define MAX_STA_CON_TO_AP 5
 
 void gpio_init(void);
+void spiffs_init(void);
+void spiffs_deinit(void);
 void esp_AP_init(void);
 void custom_tcpip_dhcp(void);
 esp_err_t change_tcpip_dhcp();

--- a/data/tekst.h.in
+++ b/data/tekst.h.in
@@ -1,0 +1,7 @@
+#ifndef TEKST_H
+#define TEKST_H
+
+const char *tekst_txt = "@TEKST_TRESC@";
+// const char *tekst_txt = "@TEKST_TRESC@"; // Inne pliki przekształcane na ciągi znaków
+
+#endif

--- a/data/tekst.txt
+++ b/data/tekst.txt
@@ -1,0 +1,1 @@
+This is a getting started guide to read, save and write to SPIFFS from ESP8266 using ESP8266_RTOS_SDK (ESP-IDF style).

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,2 +1,2 @@
 idf_component_register(SRCS "main.c"
-                       INCLUDE_DIRS ".")
+                       INCLUDE_DIRS "." "${CMAKE_BINARY_DIR}")

--- a/main/main.h
+++ b/main/main.h
@@ -16,4 +16,8 @@
 #include <sys/param.h>
 #include <esp_http_server.h>
 
+#include <sys/unistd.h>
+#include <sys/stat.h>
+#include <esp_spiffs.h>
+
 #endif

--- a/partitions.csv
+++ b/partitions.csv
@@ -1,0 +1,7 @@
+# Little changed Espressif ESP8266 Partition Table
+# "Single factory app, no OTA "
+# Name,   Type, SubType, Offset,   Size
+nvs,      data, nvs,     0x9000,   0x6000
+phy_init, data, phy,     0xf000,   0x1000
+factory,  app,  factory, 0x10000,  0xF0000
+spiffs,   data, spiffs,  0x100000, 0x100000


### PR DESCRIPTION
Add custom partition table for flash memory. Initialize SPIFFS, and verify basic file system operations with the spiffs_test task.
Also convert file from workspace (tekst.txt) to a string of characters using CMake. Then write the converted string tekst_txt (tekst.txt) to SPIFFS and read it back from SPIFFS.